### PR TITLE
Add overwrite option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ function plugin(options) {
         src: "**/*.+(html|css|js|json|xml|svg|txt)",
         gzip: {
             level: 6
-        }
+        },
+        overwrite: false
     };
 
     if (typeof options === 'object') {
@@ -36,9 +37,15 @@ function plugin(options) {
             });
 
             gzip.on('end', function concatenateCompressedChunks() {
-                var compressedFile = file + '.gz';
-                files[compressedFile] = clone(data);
-                files[compressedFile].contents = Buffer.concat(compressedChunks);
+                var compressedFile;
+
+                if (options.overwrite) {
+                    files[file].contents = Buffer.concat(compressedChunks);
+                } else {
+                    compressedFile = file + '.gz';
+                    files[compressedFile] = clone(data);
+                    files[compressedFile].contents = Buffer.concat(compressedChunks);
+                }
                 asyncDone();
             });
 


### PR DESCRIPTION
This option, if set to true, will overwrite files instead of adding a cloned .gz version.